### PR TITLE
fix bug: break timer reset, next pomo doesnt count

### DIFF
--- a/source/scripts/settings.js
+++ b/source/scripts/settings.js
@@ -147,6 +147,9 @@ mixBut.addEventListener("click", startButton);
  * resetButton is called by the reset button on the page. This button resets how much time is left on the timer to a non break amount.
  */
 export function resetButton() {
+  if (onBreak) {
+    onBreak = false;
+  }
   timeRemaining = secondsPerPomo;
 
   let minute = Math.floor(timeRemaining / 60);


### PR DESCRIPTION
bug before: if the user reset the timer while it was on break, the next pomo timer completed didn't count towards "number of completed pomos"